### PR TITLE
Add GitHub Action for tests and coverage reports

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -33,19 +33,18 @@ jobs:
 
       - name: Run tests and generate JUnit report
         run: |
-          mkdir -p target/nextest
           cargo nextest run \
             --workspace \
             --all-features \
             --no-fail-fast \
-            --junit-report target/nextest/junit.xml
+            --profile ci
 
       - name: Upload JUnit report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: junit-test-report
-          path: target/nextest/junit.xml
+          path: target/nextest/ci/junit.xml
           if-no-files-found: warn
 
       - name: Generate coverage reports


### PR DESCRIPTION
## Summary
- add `.github/workflows/test-and-coverage.yml` to run tests and coverage on `push` / `pull_request`
- run tests with `cargo nextest --profile ci` and upload JUnit report artifact
- generate LCOV + coverage summary with `cargo llvm-cov` and upload coverage artifact
- add `.config/nextest.toml` to configure JUnit output for the `ci` profile

## Verification
- `cargo test`
- GitHub Actions `test-and-coverage` passed on 2026-02-07
