### PR TITLE
Add watching repositories pane to watch TUI

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -38,7 +38,7 @@
 - `src/domain/events.rs`: `EventKind`, `WatchEvent`
 - `src/domain/decision.rs`: 通知判定/タイムライン整形
 - `src/app/poll_once.rs`: 1サイクルの監視ユースケース
-- `src/app/watch_loop.rs`: 定期実行 + TUI入力のイベントループ
+- `src/app/watch_loop.rs`: 定期実行 + TUI入力のイベントループ（enabled repo一覧をTUIモデルへ供給）
 - `src/infra/gh_client.rs`: `gh api` 実行とJSON正規化
 - `src/infra/state_sqlite.rs`: SQLite永続化
 - `src/infra/notifier/*`: OS別通知実装
@@ -96,7 +96,8 @@
 
 ## TUI仕様（実装済み）
 - Header: status / last_success / next_poll / failures
-- Main: タイムライン（新着順、選択可能）
+- Main(left 70%): タイムライン（新着順、選択可能）
+- Main(right 30%): Watching Repositories（enabled=true の監視対象repo、config記載順、閲覧専用）
 - Footer: キーガイド + 選択イベントURL
 
 ## 通知実装

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ gh-watch watch
 - `q`: 終了
 - `r`: 手動更新
 - `↑` / `↓`: タイムライン移動
+- 右ペイン（`Watching Repositories`）は閲覧専用
 
 ## Behavior
 
@@ -61,6 +62,13 @@ gh-watch watch
 - 既定 state DB パス:
   - macOS/Linux: `~/.local/share/gh-watch/state.db`
   - Windows: `%LOCALAPPDATA%\\gh-watch\\state.db`
+
+## TUI Layout
+
+- Header: `status` / `last_success` / `next_poll` / `failures` / `latest_failure`
+- Main(左 70%): `Timeline`（新着順、`↑`/`↓`で選択）
+- Main(右 30%): `Watching Repositories`（`enabled=true` の repository 一覧、config 記載順）
+- Footer: キーガイド + 選択イベント URL
 
 ## Repository Notes
 

--- a/tests/tui_state_test.rs
+++ b/tests/tui_state_test.rs
@@ -48,3 +48,15 @@ fn input_scroll_changes_selection() {
     handle_input(&mut model, InputCommand::ScrollUp);
     assert_eq!(model.selected, 0);
 }
+
+#[test]
+fn watched_repositories_start_empty_and_can_be_set() {
+    let mut model = TuiModel::new(10);
+    assert!(model.watched_repositories.is_empty());
+
+    model.watched_repositories = vec!["acme/api".to_string(), "acme/web".to_string()];
+    assert_eq!(
+        model.watched_repositories,
+        vec!["acme/api".to_string(), "acme/web".to_string()]
+    );
+}


### PR DESCRIPTION
## Summary
- add `watched_repositories: Vec<String>` to `TuiModel`
- populate watched repositories from `enabled=true` config entries in `watch_loop` (preserving config order)
- split the TUI main area into 70:30 panes and render a read-only `Watching Repositories` list on the right
- show `No enabled repositories` when no enabled repositories are configured
- update `README.md` and `AGENT.md` to reflect the new TUI layout and read-only right pane
- add unit tests for enabled repository filtering/order and TUI model watched repository state

## Testing
- `cargo test -q`
