### PR TITLE
Unify config lookup to install dir and add config commands

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -12,6 +12,8 @@
 - `gh-watch watch [--config <path>] [--interval-seconds <n>]`
 - `gh-watch check [--config <path>]`
 - `gh-watch init [--path <path>] [--force]`
+- `gh-watch config open` (`gh-watch config edit` は別名)
+- `gh-watch config path`
 
 ### `watch` の挙動
 - 起動時に `gh auth status` を検証し、失敗時は即終了
@@ -25,8 +27,16 @@
 - state DB の初期化確認
 
 ### `init` の挙動
-- 設定テンプレートを `config.toml`（または `--path`）に生成
+- 設定テンプレートを `--path` 指定先、またはバイナリ配置先の `config.toml` に生成
 - 既存ファイルがある場合は `--force` なしで失敗
+
+### `config` の挙動
+- `config open` / `config edit`
+  - バイナリ配置先 `config.toml` を開く
+  - 起動優先順: `VISUAL` -> `EDITOR` -> OS既定オープナー
+  - config 未作成時は `gh-watch init` を案内して失敗
+- `config path`
+  - 現在参照する既定 config パスを表示
 
 ## 設計方針（現在実装）
 - レイヤ分割: `domain` / `app` / `infra` / `ui` / `cli`
@@ -45,13 +55,8 @@
 - `src/ui/tui.rs`: TUIモデル・入力変換・描画
 
 ## 設定仕様（実装済み）
-- `--config` 省略時の探索順
-  - `./config.toml`
-  - `GH_WATCH_CONFIG`
-  - 既定パス
-- 既定 config パス
-  - macOS/Linux: `~/.config/gh-watch/config.toml`
-  - Windows: `%APPDATA%\\gh-watch\\config.toml`
+- `--config` を指定した場合は明示パスを読む
+- `--config` 省略時は、実行中バイナリの親ディレクトリにある `config.toml` を読む
 - 既定 state DB パス
   - macOS/Linux: `~/.local/share/gh-watch/state.db`
   - Windows: `%LOCALAPPDATA%\\gh-watch\\state.db`
@@ -109,6 +114,7 @@
 ## テスト状況
 - テストファイル群
   - `tests/config_test.rs`
+  - `tests/config_cmd_test.rs`
   - `tests/domain_decision_test.rs`
   - `tests/state_sqlite_test.rs`
   - `tests/gh_normalization_test.rs`

--- a/README.md
+++ b/README.md
@@ -22,28 +22,38 @@ cargo install --git https://github.com/6uclz1/gh-watch gh-watch
 gh-watch init
 ```
 
-2. `config.toml` の `[[repositories]]` を自分の監視対象に編集
+2. 設定ファイルをエディタで開く（`edit` は `open` の別名）
 
-3. 事前チェック
+```bash
+gh-watch config open
+# または
+gh-watch config edit
+```
+
+3. `config.toml` の `[[repositories]]` を自分の監視対象に編集
+
+4. 事前チェック
 
 ```bash
 gh-watch check
 ```
 
-4. 常駐監視 + TUI 起動
+5. 常駐監視 + TUI 起動
 
 ```bash
 gh-watch watch
 ```
 
-`--config` を省略した場合の探索順:
-- `./config.toml`
-- `GH_WATCH_CONFIG` 環境変数
-- 既定パス
+設定ファイルの既定位置:
+- 実行中 `gh-watch` バイナリと同じディレクトリの `config.toml`
 
-既定パス:
-- macOS/Linux: `~/.config/gh-watch/config.toml`
-- Windows: `%APPDATA%\\gh-watch\\config.toml`
+確認コマンド:
+
+```bash
+gh-watch config path
+```
+
+`watch` / `check` で `--config` を指定した場合のみ、明示パスを優先します。
 
 ## Key Bindings
 

--- a/tests/config_cmd_test.rs
+++ b/tests/config_cmd_test.rs
@@ -1,0 +1,179 @@
+use std::{env, fs, path::PathBuf};
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::{tempdir, TempDir};
+
+#[test]
+fn config_path_prints_binary_directory_config() {
+    let (dir, bin_path) = copy_binary_to_tempdir();
+    let expected = dir.path().join("config.toml");
+
+    let mut cmd = Command::new(&bin_path);
+    cmd.arg("config")
+        .arg("path")
+        .assert()
+        .success()
+        .stdout(contains(expected.to_string_lossy().to_string()));
+}
+
+#[test]
+fn config_open_fails_when_config_is_missing() {
+    let (_dir, bin_path) = copy_binary_to_tempdir();
+
+    let mut cmd = Command::new(&bin_path);
+    cmd.arg("config")
+        .arg("open")
+        .assert()
+        .failure()
+        .stderr(contains("run `gh-watch init` first"));
+}
+
+#[cfg(unix)]
+#[test]
+fn config_edit_alias_uses_visual_editor() {
+    let (dir, bin_path) = copy_binary_to_tempdir();
+    let config_path = dir.path().join("config.toml");
+    fs::write(&config_path, "[[repositories]]\nname = \"acme/api\"\n").unwrap();
+
+    let marker = dir.path().join("marker.txt");
+    let visual = dir.path().join("visual-editor");
+    write_executable(
+        &visual,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+echo "visual:$1" > "$MARKER"
+"#,
+    );
+
+    let mut cmd = Command::new(&bin_path);
+    cmd.arg("config")
+        .arg("edit")
+        .env("VISUAL", &visual)
+        .env_remove("EDITOR")
+        .env("MARKER", &marker)
+        .assert()
+        .success();
+
+    let got = fs::read_to_string(&marker).unwrap();
+    assert_eq!(got.trim(), format!("visual:{}", config_path.display()));
+}
+
+#[cfg(unix)]
+#[test]
+fn config_open_uses_editor_when_visual_fails() {
+    let (dir, bin_path) = copy_binary_to_tempdir();
+    let config_path = dir.path().join("config.toml");
+    fs::write(&config_path, "[[repositories]]\nname = \"acme/api\"\n").unwrap();
+
+    let marker = dir.path().join("marker.txt");
+    let visual = dir.path().join("visual-editor");
+    let editor = dir.path().join("terminal-editor");
+    write_executable(
+        &visual,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+"#,
+    );
+    write_executable(
+        &editor,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+echo "editor:$1" > "$MARKER"
+"#,
+    );
+
+    let mut cmd = Command::new(&bin_path);
+    cmd.arg("config")
+        .arg("open")
+        .env("VISUAL", &visual)
+        .env("EDITOR", &editor)
+        .env("MARKER", &marker)
+        .assert()
+        .success();
+
+    let got = fs::read_to_string(&marker).unwrap();
+    assert_eq!(got.trim(), format!("editor:{}", config_path.display()));
+}
+
+#[cfg(unix)]
+#[test]
+fn config_open_falls_back_to_os_default_opener() {
+    let (dir, bin_path) = copy_binary_to_tempdir();
+    let config_path = dir.path().join("config.toml");
+    fs::write(&config_path, "[[repositories]]\nname = \"acme/api\"\n").unwrap();
+
+    let marker = dir.path().join("marker.txt");
+    let opener = opener_script_path(dir.path());
+    write_executable(
+        &opener,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+echo "os:$1" > "$MARKER"
+"#,
+    );
+
+    let old_path = env::var_os("PATH").unwrap_or_default();
+    let mut composed = dir.path().as_os_str().to_os_string();
+    composed.push(if cfg!(windows) { ";" } else { ":" });
+    composed.push(old_path);
+
+    let mut cmd = Command::new(&bin_path);
+    cmd.arg("config")
+        .arg("open")
+        .env_remove("VISUAL")
+        .env_remove("EDITOR")
+        .env("MARKER", &marker)
+        .env("PATH", composed)
+        .assert()
+        .success();
+
+    let got = fs::read_to_string(&marker).unwrap();
+    assert_eq!(got.trim(), format!("os:{}", config_path.display()));
+}
+
+fn copy_binary_to_tempdir() -> (TempDir, PathBuf) {
+    let dir = tempdir().unwrap();
+    let src = assert_cmd::cargo::cargo_bin!("gh-watch");
+    let bin_name = if cfg!(windows) {
+        "gh-watch.exe"
+    } else {
+        "gh-watch"
+    };
+    let dst = dir.path().join(bin_name);
+    fs::copy(src, &dst).unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = fs::metadata(&dst).unwrap().permissions();
+        perm.set_mode(0o755);
+        fs::set_permissions(&dst, perm).unwrap();
+    }
+
+    (dir, dst)
+}
+
+#[cfg(unix)]
+fn write_executable(path: &PathBuf, script: &str) {
+    fs::write(path, script).unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    let mut perm = fs::metadata(path).unwrap().permissions();
+    perm.set_mode(0o755);
+    fs::set_permissions(path, perm).unwrap();
+}
+
+#[cfg(unix)]
+fn opener_script_path(base: &std::path::Path) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        return base.join("open");
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return base.join("xdg-open");
+    }
+    #[allow(unreachable_code)]
+    base.join("open")
+}

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -1,4 +1,9 @@
-use gh_watch::config::parse_config;
+use std::{
+    env,
+    sync::{Mutex, OnceLock},
+};
+
+use gh_watch::config::{parse_config, resolve_config_path};
 
 #[test]
 fn parse_config_rejects_invalid_repo_name() {
@@ -42,4 +47,49 @@ name = "octocat/hello-world"
 
     let err = parse_config(src).expect_err("zero limit should fail");
     assert!(err.to_string().contains("failure_history_limit"));
+}
+
+#[test]
+fn resolve_config_path_uses_explicit_path_when_provided() {
+    let explicit_path = env::temp_dir().join("custom-config.toml");
+    let explicit = explicit_path.as_path();
+    let resolved = resolve_config_path(Some(explicit)).expect("path should resolve");
+    assert_eq!(resolved, explicit);
+}
+
+#[test]
+fn resolve_config_path_defaults_to_installed_location() {
+    let resolved = resolve_config_path(None).expect("path should resolve");
+    let exe = env::current_exe().expect("current exe should resolve");
+    let expected = exe
+        .parent()
+        .expect("exe should have a parent")
+        .join("config.toml");
+    assert_eq!(resolved, expected);
+}
+
+#[test]
+fn resolve_config_path_ignores_gh_watch_config_env() {
+    let _guard = env_lock().lock().expect("env lock should work");
+    let prev = env::var_os("GH_WATCH_CONFIG");
+    env::set_var("GH_WATCH_CONFIG", "/tmp/legacy-config.toml");
+
+    let resolved = resolve_config_path(None).expect("path should resolve");
+    let exe = env::current_exe().expect("current exe should resolve");
+    let expected = exe
+        .parent()
+        .expect("exe should have a parent")
+        .join("config.toml");
+    assert_eq!(resolved, expected);
+
+    if let Some(prev) = prev {
+        env::set_var("GH_WATCH_CONFIG", prev);
+    } else {
+        env::remove_var("GH_WATCH_CONFIG");
+    }
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
 }

--- a/tests/init_cmd_test.rs
+++ b/tests/init_cmd_test.rs
@@ -1,8 +1,8 @@
-use std::fs;
+use std::{fs, path::PathBuf};
 
-use assert_cmd::cargo::cargo_bin_cmd;
+use assert_cmd::{cargo::cargo_bin_cmd, Command};
 use predicates::str::contains;
-use tempfile::tempdir;
+use tempfile::{tempdir, TempDir};
 
 #[test]
 fn init_creates_config_file() {
@@ -43,4 +43,38 @@ fn init_prevents_overwrite_without_force() {
 
     let content = fs::read_to_string(path).unwrap();
     assert!(content.contains("[[repositories]]"));
+}
+
+#[test]
+fn init_without_path_uses_binary_directory_config() {
+    let (dir, bin_path) = copy_binary_to_tempdir();
+    let config_path = dir.path().join("config.toml");
+
+    let mut cmd = Command::new(&bin_path);
+    cmd.arg("init").assert().success();
+
+    let content = fs::read_to_string(config_path).unwrap();
+    assert!(content.contains("[[repositories]]"));
+}
+
+fn copy_binary_to_tempdir() -> (TempDir, PathBuf) {
+    let dir = tempdir().unwrap();
+    let src = assert_cmd::cargo::cargo_bin!("gh-watch");
+    let bin_name = if cfg!(windows) {
+        "gh-watch.exe"
+    } else {
+        "gh-watch"
+    };
+    let dst = dir.path().join(bin_name);
+    fs::copy(src, &dst).unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = fs::metadata(&dst).unwrap().permissions();
+        perm.set_mode(0o755);
+        fs::set_permissions(&dst, perm).unwrap();
+    }
+
+    (dir, dst)
 }


### PR DESCRIPTION
## Summary
- unify default config lookup to the installed binary directory (`config.toml` next to `gh-watch`)
- make `gh-watch init` default to that same installed location when `--path` is omitted
- add `gh-watch config open` and `gh-watch config path` (`config edit` as alias)
- implement editor fallback order: `VISUAL` -> `EDITOR` -> OS default opener
- update docs and add integration tests for new config command behavior

## Testing
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
