### PR TITLE
[P2] TUI操作性改善: ヘルプ表示・移動キー拡張・選択保持

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ gh-watch config path
 
 - `q`: 終了
 - `r`: 手動更新
-- `↑` / `↓`: タイムライン移動
+- `?`: ヘルプ表示の ON/OFF
+- `↑` / `↓` または `j` / `k`: タイムラインを1件移動
+- `PageUp` / `PageDown`: タイムラインを1ページ移動
+- `g` / `Home`: 先頭へ移動
+- `G` / `End`: 末尾へ移動
 - `Enter`: 選択中タイムライン項目の URL を既定ブラウザで開く
 - マウス:
   - 左クリック（タイムライン左ペイン内）: 項目選択
@@ -82,7 +86,9 @@ gh-watch config path
 - Header: `status` / `last_success` / `next_poll` / `failures` / `latest_failure`
 - Main(左 70%): `Timeline`（新着順、`↑`/`↓`で選択）
 - Main(右 30%): `Watching Repositories`（`enabled=true` の repository 一覧、config 記載順）
-- Footer: キーガイド + 選択イベント URL
+- Selected: 選択イベントの要約 + URL
+- Footer: キーガイド（固定表示）
+- Overlay: `?` でヘルプ表示
 
 ## Repository Notes
 


### PR DESCRIPTION
## 概要
TUIの操作で迷いが出やすい点を改善しました。主に以下の3点です。

1. `?` でヘルプ表示をトグルできるようにした
2. キーボード移動を拡張した（`j/k`, `PageUp/PageDown`, `g/G`, `Home/End`）
3. ポーリング更新後も、可能な限り同じイベントを選択し続けるようにした（`event_key` ベース）

## 変更内容
- `InputCommand` を拡張（`ToggleHelp`, `PageUp`, `PageDown`, `JumpTop`, `JumpBottom`）
- キーマップ追加（`?`, `j/k`, `PageUp/PageDown`, `g/G`, `Home/End`）
- `TuiModel` に状態追加
  - `help_visible`
  - `timeline_page_size`
  - `selected_event_key`
- `push_timeline` の選択保持を index ベースから `event_key` ベースへ変更
- フッターを固定のキーガイドにし、選択中URLは `Selected` パネルへ分離
- ヘルプオーバーレイ表示を追加
- README のキー操作・レイアウト説明を更新

## 動作確認
- `?` でヘルプの表示/非表示が切り替わる
- `j/k` と矢印で1件移動できる
- `PageUp/PageDown` でページ移動できる
- `g/G` と `Home/End` で先頭/末尾に移動できる
- 新規イベント追加後も、既存選択イベントが残っていれば同じイベントを選択し続ける

## テスト
- `cargo test --test tui_state_test`
- `cargo test`

## 関連
Closes #16
