### PR TITLE
feat: TUIの可読性改善とpoll中の非ブロッキング操作対応

### DIFF
--- a/tests/tui_state_test.rs
+++ b/tests/tui_state_test.rs
@@ -55,6 +55,9 @@ fn input_scroll_changes_selection() {
 fn watched_repositories_start_empty_and_can_be_set() {
     let mut model = TuiModel::new(10);
     assert!(model.watched_repositories.is_empty());
+    assert!(!model.is_polling);
+    assert!(model.poll_started_at.is_none());
+    assert!(!model.queued_refresh);
 
     model.watched_repositories = vec!["acme/api".to_string(), "acme/web".to_string()];
     assert_eq!(
@@ -226,6 +229,20 @@ fn mouse_click_in_timeline_selects_row_using_offset() {
 
     let cmd = parse_mouse_input(click, area, &model);
     assert_eq!(cmd, InputCommand::SelectIndex(2));
+}
+
+#[test]
+fn polling_state_fields_are_mutable_for_loading_transitions() {
+    let mut model = TuiModel::new(10);
+    let started_at = Utc.with_ymd_and_hms(2025, 1, 5, 12, 30, 0).unwrap();
+
+    model.is_polling = true;
+    model.poll_started_at = Some(started_at);
+    model.queued_refresh = true;
+
+    assert!(model.is_polling);
+    assert_eq!(model.poll_started_at, Some(started_at));
+    assert!(model.queued_refresh);
 }
 
 #[test]


### PR DESCRIPTION
## 概要
TUIの見やすさと操作性を改善しました。主に以下を対応しています。

- Timelineをテーブル表示化（`Time/Type/Repo/Actor/Title`）
- 種別ごとの色分け、時刻表示の短縮、Selectedペイン整理
- fetch(poll)中のloading状態可視化（経過秒・refreshキュー状態）
- pollを非ブロッキング化し、loading中も入力操作を継続可能に変更
- `r`連打時は多重pollせず、次回refreshを1回だけキュー化

## 変更点
- `src/ui/tui.rs`
  - `List` -> `Table` へ変更
  - `TuiModel`に`is_polling`/`poll_started_at`/`queued_refresh`を追加
  - loading表示とキーガイド表示を改善
  - Timelineクリック選択の行計算を1行1イベント前提へ更新
- `src/app/watch_loop.rs`
  - `PollExecutionState`を導入し、単一in-flight pollを管理
  - `tokio::select!`で入力/タイマー/poll完了を同時待機
  - poll結果反映ロジックを`apply_poll_result`へ分離
- `tests/tui_state_test.rs`
  - loading状態フィールド、クリック選択行計算の回帰テストを追加

## テスト
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## 関連Issue
Closes #18
Closes #19
Closes #20
Closes #21
Closes #22
