### PR TITLE
initに --reset-state を追加して state.db を明示初期化できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ cargo install --git https://github.com/6uclz1/gh-watch gh-watch
 gh-watch init
 ```
 
+既存 `state.db` を初期化したい場合:
+
+```bash
+gh-watch init --reset-state
+# 明示 config を使う場合
+gh-watch init --reset-state --path ./config.toml
+```
+
 2. 設定ファイルをエディタで開く（`edit` は `open` の別名）
 
 ```bash

--- a/tests/init_cmd_test.rs
+++ b/tests/init_cmd_test.rs
@@ -1,4 +1,7 @@
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use assert_cmd::{cargo::cargo_bin_cmd, Command};
 use predicates::str::contains;
@@ -164,6 +167,136 @@ exit 1
     assert!(content.contains("name = \"acme/web\""));
 }
 
+#[test]
+fn init_reset_state_recreates_custom_state_db() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let state_db = dir.path().join("state.db");
+    write_config_with_state_db_path(&config_path, &state_db);
+    seed_legacy_timeline_event(&state_db);
+    assert_eq!(timeline_event_count(&state_db), 1);
+
+    let mut cmd = cargo_bin_cmd!("gh-watch");
+    cmd.arg("init")
+        .arg("--reset-state")
+        .arg("--path")
+        .arg(&config_path)
+        .assert()
+        .success()
+        .stdout(contains("reset state db:"))
+        .stdout(contains(state_db.display().to_string()));
+
+    assert!(state_db.exists());
+    assert_eq!(timeline_event_count(&state_db), 0);
+}
+
+#[test]
+fn init_reset_state_keeps_config_file_unchanged() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let state_db = dir.path().join("state.db");
+    write_config_with_state_db_path(&config_path, &state_db);
+    let before = fs::read_to_string(&config_path).unwrap();
+
+    let mut cmd = cargo_bin_cmd!("gh-watch");
+    cmd.arg("init")
+        .arg("--reset-state")
+        .arg("--path")
+        .arg(&config_path)
+        .assert()
+        .success();
+
+    let after = fs::read_to_string(&config_path).unwrap();
+    assert_eq!(before, after);
+}
+
+#[test]
+fn init_reset_state_rejects_interactive_mode() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    write_config_with_state_db_path(&config_path, &dir.path().join("state.db"));
+
+    let mut cmd = cargo_bin_cmd!("gh-watch");
+    cmd.arg("init")
+        .arg("--reset-state")
+        .arg("--interactive")
+        .arg("--path")
+        .arg(&config_path)
+        .assert()
+        .failure()
+        .stderr(contains("--reset-state cannot be used with --interactive"));
+}
+
+#[test]
+fn init_reset_state_fails_when_config_is_invalid() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    fs::write(
+        &config_path,
+        r#"
+interval_seconds = "oops"
+
+[[repositories]]
+name = "acme/api"
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = cargo_bin_cmd!("gh-watch");
+    cmd.arg("init")
+        .arg("--reset-state")
+        .arg("--path")
+        .arg(&config_path)
+        .assert()
+        .failure()
+        .stderr(contains("failed to parse config TOML"));
+}
+
+#[test]
+fn init_reset_state_uses_default_state_db_when_config_is_missing() {
+    let dir = tempdir().unwrap();
+    let missing_config = dir.path().join("missing.toml");
+
+    #[cfg(not(windows))]
+    let expected_state = {
+        let home = dir.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+
+        let mut cmd = cargo_bin_cmd!("gh-watch");
+        cmd.arg("init")
+            .arg("--reset-state")
+            .arg("--path")
+            .arg(&missing_config)
+            .env("HOME", &home)
+            .assert()
+            .success();
+
+        home.join(".local")
+            .join("share")
+            .join("gh-watch")
+            .join("state.db")
+    };
+
+    #[cfg(windows)]
+    let expected_state = {
+        let local_appdata = dir.path().join("localappdata");
+        fs::create_dir_all(&local_appdata).unwrap();
+
+        let mut cmd = cargo_bin_cmd!("gh-watch");
+        cmd.arg("init")
+            .arg("--reset-state")
+            .arg("--path")
+            .arg(&missing_config)
+            .env("LOCALAPPDATA", &local_appdata)
+            .assert()
+            .success();
+
+        local_appdata.join("gh-watch").join("state.db")
+    };
+
+    assert!(expected_state.exists());
+}
+
 fn copy_binary_to_tempdir() -> (TempDir, PathBuf) {
     let dir = tempdir().unwrap();
     let src = assert_cmd::cargo::cargo_bin!("gh-watch");
@@ -199,4 +332,52 @@ fn write_stub_gh(dir: &std::path::Path, script: &str) -> PathBuf {
     }
 
     path
+}
+
+fn write_config_with_state_db_path(config_path: &Path, state_db_path: &Path) {
+    let escaped = state_db_path.display().to_string().replace('\\', "\\\\");
+    let src = format!(
+        r#"
+interval_seconds = 300
+state_db_path = "{escaped}"
+
+[[repositories]]
+name = "acme/api"
+"#
+    );
+    fs::write(config_path, src).unwrap();
+}
+
+fn seed_legacy_timeline_event(state_db_path: &Path) {
+    if let Some(parent) = state_db_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+
+    let conn = rusqlite::Connection::open(state_db_path).unwrap();
+    conn.execute_batch(
+        "
+CREATE TABLE IF NOT EXISTS timeline_events (
+  event_key TEXT PRIMARY KEY,
+  payload_json TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+",
+    )
+    .unwrap();
+
+    let payload = r#"{"event_id":"pr:1","repo":"acme/api","kind":"PrCreated","actor":"alice","title":"hello","url":"https://example.com/pull/1","created_at":"2026-02-07T16:15:06Z","source_item_id":"1"}"#;
+    conn.execute(
+        "
+INSERT OR REPLACE INTO timeline_events (event_key, payload_json, created_at)
+VALUES (?1, ?2, ?3)
+",
+        rusqlite::params!["acme/api:pr_created:1", payload, "2026-02-07T16:15:06Z"],
+    )
+    .unwrap();
+}
+
+fn timeline_event_count(state_db_path: &Path) -> i64 {
+    let conn = rusqlite::Connection::open(state_db_path).unwrap();
+    conn.query_row("SELECT COUNT(*) FROM timeline_events", [], |row| row.get(0))
+        .unwrap()
 }


### PR DESCRIPTION
## 背景
既存の `state.db` に旧形式のイベント種別（例: `PrCreated`）が残っていると、現行実装で読み込めず実行時エラーになるケースがありました。

今回の対応では後方互換読み取りは入れず、**明示的に state を初期化するコマンド**を追加しています。

## 変更内容
- `gh-watch init --reset-state` を追加
- `--reset-state` 実行時は `config.toml` を書き換えず、`state.db` のみを初期化
- `--path` 指定時は、その config を読んで `state_db_path` を解決
- config が存在しない場合は既定の state DB パスを初期化
- `--reset-state` と `--interactive` の同時指定はエラー
- config が存在していてパース不能な場合はエラーで停止
- DB初期化時に `state.db` 本体に加えて `-wal` / `-shm` も削除して再作成
- README に使用例を追記

## テスト
以下をローカルで実行し、全件成功を確認しました。

```bash
cargo test
```

追加した主なテスト:
- custom `state_db_path` の DB が再作成されること
- 旧データ入り DB を初期化後、`timeline_events` が空になること
- `init --reset-state` で config ファイルが変更されないこと
- `--reset-state --interactive` が失敗すること
- config パースエラー時に失敗すること
- config 不在時に既定 state DB が作成されること

## 使い方
```bash
gh-watch init --reset-state
# または
gh-watch init --reset-state --path ./config.toml
```
