### PR TITLE
CIの重複実行を防止: pushトリガーをmain限定に変更

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -2,7 +2,10 @@ name: Test and Coverage Report
 
 on:
   pull_request:
+  # Avoid duplicate CI runs on PR branches; keep push-triggered CI for main only.
   push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## 背景
PRブランチへの push 時に、`pull_request` と `push` の両方が走ってテストが二重実行されていました。

## 変更内容
- `/Users/6uclz1/ws/gh-watch/.github/workflows/test-and-coverage.yml` のトリガーを変更
- `push` を全ブランチ対象から `main` のみに限定
- 意図を明確にするコメントを1行追加

## 変更後の挙動
- PRブランチへの push: `pull_request` のみ実行
- `main` への push（直接push / PRマージ後）: `push` が1回実行

## 影響範囲
- ワークフロー名・ジョブ名・テスト手順（fmt/clippy/nextest/coverage）は変更なし
- 変更はトリガー条件のみ

## 確認
- YAML構文チェック: `YAML OK`
- 差分が対象ファイル1件のみであることを確認
