### PR TITLE
feat: once/report/doctor追加とREADME日英分割

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target_name: linux
+          - os: macos-latest
+            target_name: macos
+          - os: windows-latest
+            target_name: windows
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --locked
+
+      - name: Package binary and docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME:-dev}"
+          TARGET="${{ matrix.target_name }}"
+          DIST_DIR="dist"
+          mkdir -p "$DIST_DIR"
+
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            BIN="target/release/gh-watch.exe"
+            ARCHIVE="gh-watch-${VERSION}-${TARGET}.zip"
+            cp "$BIN" "$DIST_DIR/gh-watch.exe"
+            cp README.md "$DIST_DIR/README.md"
+            cp README_ja.md "$DIST_DIR/README_ja.md"
+            cp config.example.toml "$DIST_DIR/config.example.toml"
+            (
+              cd "$DIST_DIR"
+              7z a -tzip "../${ARCHIVE}" gh-watch.exe README.md README_ja.md config.example.toml > /dev/null
+            )
+          else
+            BIN="target/release/gh-watch"
+            ARCHIVE="gh-watch-${VERSION}-${TARGET}.tar.gz"
+            cp "$BIN" "$DIST_DIR/gh-watch"
+            cp README.md "$DIST_DIR/README.md"
+            cp README_ja.md "$DIST_DIR/README_ja.md"
+            cp config.example.toml "$DIST_DIR/config.example.toml"
+            tar -C "$DIST_DIR" -czf "$ARCHIVE" gh-watch README.md README_ja.md config.example.toml
+          fi
+
+          sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target_name }}
+          path: |
+            gh-watch-*.tar.gz
+            gh-watch-*.tar.gz.sha256
+            gh-watch-*.zip
+            gh-watch-*.zip.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Publish Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/**/*.tar.gz
+            dist/**/*.tar.gz.sha256
+            dist/**/*.zip
+            dist/**/*.zip.sha256

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "gh-watch"
 version = "0.1.0"
 edition = "2021"
+description = "Reliable GitHub PR/Issue watcher with desktop notifications and a TUI timeline"
+license = "UNLICENSED"
+repository = "https://github.com/6uclz1/gh-watch"
+homepage = "https://github.com/6uclz1/gh-watch"
+readme = "README.md"
+categories = ["command-line-utilities", "development-tools"]
+keywords = ["github", "notifications", "cli", "tui", "watcher"]
 
 [lib]
 name = "gh_watch"

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,155 @@
+# gh-watch
+
+デスクトップ通知と TUI タイムラインを備えた、ローカル実行型の GitHub 監視ツールです。
+
+`gh-watch` はローカルで常駐し、対象リポジトリを定期ポーリングしてイベントを重複なく通知します。
+
+English README: [README.md](README.md)
+
+## 5分でできること
+
+1. 1つの設定で複数リポジトリを監視
+2. PR / Issue / コメント / レビュー / マージを通知
+3. SQLite の event key で再起動後も重複通知を防止
+4. 通知失敗時は再試行（at-least-once）
+
+## デモ
+
+- 次のリリースでデモ素材を追加予定:
+- 30-45秒の操作GIF
+- タイムライン画面キャプチャ
+- フィルタ/検索画面キャプチャ
+
+## 前提条件
+
+- Rust 1.93+
+- `gh` CLI
+- `gh` 認証済み
+
+```bash
+gh auth login -h github.com
+```
+
+## インストール
+
+### Cargo（現行）
+
+```bash
+cargo install --git https://github.com/6uclz1/gh-watch gh-watch
+```
+
+### GitHub Releases
+
+タグ付きリリース時に macOS / Linux / Windows 向けバイナリを配布します。
+
+## クイックスタート
+
+1. 設定作成
+
+```bash
+gh-watch init
+```
+
+2. 設定を開く
+
+```bash
+gh-watch config open
+```
+
+3. `[[repositories]]` を編集
+
+4. 事前チェック
+
+```bash
+gh-watch check
+```
+
+5. 常駐監視 + TUI 起動
+
+```bash
+gh-watch watch
+```
+
+## 主なコマンド
+
+- `gh-watch watch [--config <path>] [--interval-seconds <n>]`
+- `gh-watch once [--config <path>] [--dry-run] [--json]`
+- `gh-watch report [--config <path>] [--since <duration>] [--format markdown|json]`
+- `gh-watch doctor [--config <path>]`
+- `gh-watch check [--config <path>]`
+- `gh-watch init [--path <path>] [--force] [--interactive] [--reset-state]`
+- `gh-watch config open|edit`
+- `gh-watch config path`
+- `gh-watch config doctor`
+
+### `once` の終了コード
+
+- `0`: 成功
+- `2`: 一部リポジトリで失敗（部分失敗）
+- `1`: 致命的エラー
+
+## 監視イベント
+
+- `pr_created`
+- `issue_created`
+- `issue_comment_created`
+- `pr_review_comment_created`
+- `pr_review_requested`
+- `pr_review_submitted`
+- `pr_merged`
+
+## フィルタ
+
+グローバルフィルタ:
+
+- `[filters].event_kinds`
+- `[filters].ignore_actors`
+- `[filters].only_involving_me`
+
+`only_involving_me = true` のとき、次を満たすイベントのみ通知:
+
+- 自分宛てのレビュー依頼
+- コメント/レビュー本文で自分がメンションされている
+- 自分が作成した PR / Issue への更新
+
+## at-least-once 通知セマンティクス
+
+- 初回はカーソル初期化のみ（通知なし）
+- `event_key` で重複通知を防止
+- 通知失敗時はカーソル巻き戻しで再試行
+- あるリポジトリの失敗が他リポジトリを止めない
+
+## TUI キーバインド
+
+- `q`: 終了
+- `r`: 手動更新
+- `/`: 検索開始
+- `f`: kind フィルタ切替
+- `Esc`: 検索/フィルタ解除
+- `?`: ヘルプ表示切替
+- `Enter`: 選択URLを開く
+- `↑` / `↓` or `j` / `k`: 1件移動
+- `PageUp` / `PageDown`: 1ページ移動
+- `g` / `Home`: 先頭
+- `G` / `End`: 末尾
+- マウスクリック/ホイール: 選択/スクロール
+
+## 設定ファイル解決順
+
+1. `--config <path>`
+2. `GH_WATCH_CONFIG`
+3. `./config.toml`
+4. バイナリ配置ディレクトリの `config.toml`
+
+既定の state DB:
+
+- macOS/Linux: `~/.local/share/gh-watch/state.db`
+- Windows: `%LOCALAPPDATA%\gh-watch\state.db`
+
+共有用テンプレートは `config.example.toml` を利用してください。
+
+## 開発時の品質ゲート
+
+- `cargo fmt --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test`

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,8 +10,9 @@ enabled = true
 include_url = true
 
 [filters]
-# event_kinds = ["pr_created", "issue_created", "issue_comment_created", "pr_review_comment_created"]
+# event_kinds = ["pr_created", "issue_created", "issue_comment_created", "pr_review_comment_created", "pr_review_requested", "pr_review_submitted", "pr_merged"]
 # ignore_actors = ["dependabot[bot]"]
+# only_involving_me = false
 
 [poll]
 max_concurrency = 4

--- a/src/app/watch_loop.rs
+++ b/src/app/watch_loop.rs
@@ -623,6 +623,9 @@ mod tests {
             url: "https://example.com/ev1".to_string(),
             created_at: clock.now,
             source_item_id: "ev1".to_string(),
+            subject_author: Some("dev".to_string()),
+            requested_reviewer: None,
+            mentions: Vec::new(),
         }];
         model.selected = 0;
 
@@ -658,6 +661,9 @@ mod tests {
             url: "https://example.com/ev2".to_string(),
             created_at: clock.now,
             source_item_id: "ev2".to_string(),
+            subject_author: Some("dev".to_string()),
+            requested_reviewer: None,
+            mentions: Vec::new(),
         }];
         model.selected = 0;
 
@@ -768,6 +774,9 @@ mod tests {
                 url: "https://example.com/ev1".to_string(),
                 created_at: clock.now,
                 source_item_id: "ev1".to_string(),
+                subject_author: Some("dev".to_string()),
+                requested_reviewer: None,
+                mentions: Vec::new(),
             },
             WatchEvent {
                 event_id: "ev2".to_string(),
@@ -778,6 +787,9 @@ mod tests {
                 url: "https://example.com/ev2".to_string(),
                 created_at: clock.now,
                 source_item_id: "ev2".to_string(),
+                subject_author: Some("dev".to_string()),
+                requested_reviewer: None,
+                mentions: Vec::new(),
             },
             WatchEvent {
                 event_id: "ev3".to_string(),
@@ -788,6 +800,9 @@ mod tests {
                 url: "https://example.com/ev3".to_string(),
                 created_at: clock.now,
                 source_item_id: "ev3".to_string(),
+                subject_author: Some("dev".to_string()),
+                requested_reviewer: None,
+                mentions: Vec::new(),
             },
         ];
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,8 @@ pub struct FiltersConfig {
     pub event_kinds: Vec<EventKind>,
     #[serde(default)]
     pub ignore_actors: Vec<String>,
+    #[serde(default)]
+    pub only_involving_me: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/domain/decision.rs
+++ b/src/domain/decision.rs
@@ -4,7 +4,7 @@ use super::events::WatchEvent;
 
 #[derive(Debug, Clone)]
 pub enum NotificationDecision {
-    Notify(WatchEvent),
+    Notify(Box<WatchEvent>),
     SkipAlreadyNotified,
     SkipBootstrap,
 }
@@ -19,7 +19,7 @@ pub fn decide_notification(
     } else if already_notified.contains(&event.event_key()) {
         NotificationDecision::SkipAlreadyNotified
     } else {
-        NotificationDecision::Notify(event.clone())
+        NotificationDecision::Notify(Box::new(event.clone()))
     }
 }
 

--- a/src/domain/failure.rs
+++ b/src/domain/failure.rs
@@ -1,11 +1,12 @@
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 pub const FAILURE_KIND_REPO_POLL: &str = "repo_poll";
 pub const FAILURE_KIND_NOTIFICATION: &str = "notification";
 pub const FAILURE_KIND_POLL_LOOP: &str = "poll_loop";
 pub const FAILURE_KIND_INPUT_STREAM: &str = "input_stream";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FailureRecord {
     pub kind: String,
     pub repo: String,

--- a/src/infra/notifier/mod.rs
+++ b/src/infra/notifier/mod.rs
@@ -222,6 +222,9 @@ mod tests {
             url: "https://example.com/pr/1".to_string(),
             created_at: Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
             source_item_id: "1".to_string(),
+            subject_author: Some("alice".to_string()),
+            requested_reviewer: None,
+            mentions: Vec::new(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-use anyhow::Result;
-
 #[tokio::main]
-async fn main() -> Result<()> {
-    gh_watch::cli::run().await
+async fn main() {
+    if let Err(err) = gh_watch::cli::run().await {
+        eprintln!("{err:#}");
+        std::process::exit(gh_watch::cli::exit_code_for_error(&err));
+    }
 }

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -7,6 +7,7 @@ use crate::domain::{events::WatchEvent, failure::FailureRecord};
 #[async_trait]
 pub trait GhClientPort: Send + Sync {
     async fn check_auth(&self) -> Result<()>;
+    async fn viewer_login(&self) -> Result<String>;
     async fn fetch_repo_events(&self, repo: &str, since: DateTime<Utc>) -> Result<Vec<WatchEvent>>;
 }
 

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -54,6 +54,9 @@ pub enum TimelineKindFilter {
     IssueCreated,
     IssueCommentCreated,
     PrReviewCommentCreated,
+    PrReviewRequested,
+    PrReviewSubmitted,
+    PrMerged,
 }
 
 impl TimelineKindFilter {
@@ -63,6 +66,9 @@ impl TimelineKindFilter {
             Self::IssueCreated => "ISSUE",
             Self::IssueCommentCreated => "I-CMT",
             Self::PrReviewCommentCreated => "PR-CMT",
+            Self::PrReviewRequested => "PR-REQ",
+            Self::PrReviewSubmitted => "PR-REV",
+            Self::PrMerged => "PR-MRG",
         }
     }
 
@@ -72,6 +78,9 @@ impl TimelineKindFilter {
             Self::IssueCreated => matches!(kind, EventKind::IssueCreated),
             Self::IssueCommentCreated => matches!(kind, EventKind::IssueCommentCreated),
             Self::PrReviewCommentCreated => matches!(kind, EventKind::PrReviewCommentCreated),
+            Self::PrReviewRequested => matches!(kind, EventKind::PrReviewRequested),
+            Self::PrReviewSubmitted => matches!(kind, EventKind::PrReviewSubmitted),
+            Self::PrMerged => matches!(kind, EventKind::PrMerged),
         }
     }
 
@@ -80,7 +89,10 @@ impl TimelineKindFilter {
             Self::PrCreated => Some(Self::IssueCreated),
             Self::IssueCreated => Some(Self::IssueCommentCreated),
             Self::IssueCommentCreated => Some(Self::PrReviewCommentCreated),
-            Self::PrReviewCommentCreated => None,
+            Self::PrReviewCommentCreated => Some(Self::PrReviewRequested),
+            Self::PrReviewRequested => Some(Self::PrReviewSubmitted),
+            Self::PrReviewSubmitted => Some(Self::PrMerged),
+            Self::PrMerged => None,
         }
     }
 }
@@ -583,6 +595,9 @@ fn event_kind_label(kind: &EventKind) -> &'static str {
         EventKind::IssueCreated => "ISSUE",
         EventKind::IssueCommentCreated => "I-CMT",
         EventKind::PrReviewCommentCreated => "PR-CMT",
+        EventKind::PrReviewRequested => "PR-REQ",
+        EventKind::PrReviewSubmitted => "PR-REV",
+        EventKind::PrMerged => "PR-MRG",
     }
 }
 
@@ -592,6 +607,9 @@ fn event_kind_style(kind: &EventKind) -> Style {
         EventKind::IssueCreated => Style::default().fg(Color::Yellow),
         EventKind::IssueCommentCreated => Style::default().fg(Color::Green),
         EventKind::PrReviewCommentCreated => Style::default().fg(Color::Magenta),
+        EventKind::PrReviewRequested => Style::default().fg(Color::Blue),
+        EventKind::PrReviewSubmitted => Style::default().fg(Color::LightBlue),
+        EventKind::PrMerged => Style::default().fg(Color::LightGreen),
     }
 }
 

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -41,6 +41,7 @@ name = "octocat/hello-world"
     assert!(cfg.notifications.include_url);
     assert!(cfg.filters.event_kinds.is_empty());
     assert!(cfg.filters.ignore_actors.is_empty());
+    assert!(!cfg.filters.only_involving_me);
     assert_eq!(cfg.poll.max_concurrency, 4);
     assert_eq!(cfg.poll.timeout_seconds, 30);
 }
@@ -105,6 +106,7 @@ fn parse_config_parses_global_filters_and_repo_override_event_kinds() {
 [filters]
 event_kinds = ["pr_created", "issue_created"]
 ignore_actors = ["dependabot[bot]"]
+only_involving_me = true
 
 [[repositories]]
 name = "octocat/hello-world"
@@ -117,6 +119,7 @@ event_kinds = ["pr_created"]
         cfg.filters.ignore_actors,
         vec!["dependabot[bot]".to_string()]
     );
+    assert!(cfg.filters.only_involving_me);
     assert_eq!(cfg.repositories.len(), 1);
     assert_eq!(
         cfg.repositories[0]

--- a/tests/domain_decision_test.rs
+++ b/tests/domain_decision_test.rs
@@ -14,6 +14,9 @@ fn sample_event(id: &str, created_at: chrono::DateTime<Utc>) -> WatchEvent {
         url: "https://example.com/pr/1".to_string(),
         created_at,
         source_item_id: id.to_string(),
+        subject_author: Some("alice".to_string()),
+        requested_reviewer: None,
+        mentions: Vec::new(),
     }
 }
 

--- a/tests/gh_normalization_test.rs
+++ b/tests/gh_normalization_test.rs
@@ -31,3 +31,56 @@ fn normalize_events_filters_by_since_and_maps_kinds() {
         .any(|e| e.kind == EventKind::PrReviewCommentCreated));
     assert!(events.iter().all(|e| e.created_at > since));
 }
+
+#[test]
+fn normalize_events_maps_review_requested_review_submitted_and_merged() {
+    let pulls = r#"
+[
+  {
+    "id": 10,
+    "number": 10,
+    "title": "New pull",
+    "html_url": "https://example.com/pr/10",
+    "created_at": "2025-01-03T00:00:00Z",
+    "updated_at": "2025-01-06T00:00:00Z",
+    "merged_at": "2025-01-06T00:00:00Z",
+    "user": {"login": "bob"},
+    "requested_reviewers": [{"login": "alice"}]
+  }
+]
+"#;
+    let issues = "[]";
+    let issue_comments = "[]";
+    let review_comments = r#"
+[
+  {
+    "id": 41,
+    "pull_request_review_id": 9001,
+    "pull_request_url": "https://api.github.com/repos/acme/api/pulls/10",
+    "html_url": "https://example.com/pr/10#pullrequestreview-9001",
+    "created_at": "2025-01-05T00:00:00Z",
+    "body": "@alice looks good",
+    "user": {"login": "frank"}
+  }
+]
+"#;
+
+    let since = Utc.with_ymd_and_hms(2025, 1, 2, 0, 0, 0).unwrap();
+    let events = normalize_events_from_payloads(
+        "acme/api",
+        since,
+        pulls,
+        issues,
+        issue_comments,
+        review_comments,
+    )
+    .unwrap();
+
+    assert!(events
+        .iter()
+        .any(|e| e.kind == EventKind::PrReviewRequested));
+    assert!(events
+        .iter()
+        .any(|e| e.kind == EventKind::PrReviewSubmitted));
+    assert!(events.iter().any(|e| e.kind == EventKind::PrMerged));
+}

--- a/tests/notifier_test.rs
+++ b/tests/notifier_test.rs
@@ -13,6 +13,9 @@ fn notification_body_contains_url_when_enabled() {
         url: "https://example.com/pr/1".to_string(),
         created_at: Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
         source_item_id: "1".to_string(),
+        subject_author: Some("alice".to_string()),
+        requested_reviewer: None,
+        mentions: Vec::new(),
     };
 
     let body = build_notification_body(&event, true);

--- a/tests/once_report_doctor_cmd_test.rs
+++ b/tests/once_report_doctor_cmd_test.rs
@@ -1,0 +1,345 @@
+use std::{fs, path::Path, path::PathBuf};
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use chrono::{Duration, Utc};
+use gh_watch::domain::{
+    events::{EventKind, WatchEvent},
+    failure::FailureRecord,
+};
+use gh_watch::infra::state_sqlite::SqliteStateStore;
+use gh_watch::ports::StateStorePort;
+use predicates::str::contains;
+use tempfile::tempdir;
+
+#[test]
+fn once_json_returns_partial_failure_exit_code_2() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let state_db_path = dir.path().join("state.db");
+    write_config(&config_path, &state_db_path, &["acme/api", "acme/web"]);
+
+    let gh_path = write_stub_gh(
+        dir.path(),
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "auth" && "$2" == "status" ]]; then
+  exit 0
+fi
+if [[ "$1" == "api" ]]; then
+  endpoint="${@: -1}"
+  if [[ "$endpoint" == "repos/acme/web/pulls"* ]]; then
+    echo "boom" >&2
+    exit 1
+  fi
+  if [[ "$endpoint" == "repos/acme/api/pulls"* ]]; then
+    echo '[]'
+    exit 0
+  fi
+  if [[ "$endpoint" == "repos/acme/api/issues"* ]]; then
+    echo '[]'
+    exit 0
+  fi
+  if [[ "$endpoint" == "repos/acme/web/issues"* ]]; then
+    echo '[]'
+    exit 0
+  fi
+  if [[ "$endpoint" == "repos/acme/api/issues/comments"* ]]; then
+    echo '[[]]'
+    exit 0
+  fi
+  if [[ "$endpoint" == "repos/acme/web/issues/comments"* ]]; then
+    echo '[[]]'
+    exit 0
+  fi
+  if [[ "$endpoint" == "repos/acme/api/pulls/comments"* ]]; then
+    echo '[[]]'
+    exit 0
+  fi
+  if [[ "$endpoint" == "repos/acme/web/pulls/comments"* ]]; then
+    echo '[[]]'
+    exit 0
+  fi
+fi
+echo "unexpected args: $@" >&2
+exit 1
+"#,
+    );
+
+    let mut cmd = cargo_bin_cmd!("gh-watch");
+    cmd.arg("once")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--json")
+        .env("GH_WATCH_GH_BIN", gh_path)
+        .assert()
+        .failure()
+        .code(2)
+        .stdout(contains("\"repo_errors\":["));
+}
+
+#[test]
+fn help_lists_once_report_and_doctor_commands() {
+    let mut cmd = cargo_bin_cmd!("gh-watch");
+    cmd.arg("--help")
+        .assert()
+        .success()
+        .stdout(contains("once"))
+        .stdout(contains("report"))
+        .stdout(contains("doctor"));
+}
+
+#[test]
+fn once_dry_run_keeps_cursor_and_tables_unchanged() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let state_db_path = dir.path().join("state.db");
+    write_config(&config_path, &state_db_path, &["acme/api"]);
+
+    let cursor = Utc::now() - Duration::hours(2);
+    let store = SqliteStateStore::new(&state_db_path).unwrap();
+    store.set_cursor("acme/api", cursor).unwrap();
+
+    let gh_path = write_stub_gh(
+        dir.path(),
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "auth" && "$2" == "status" ]]; then
+  exit 0
+fi
+if [[ "$1" == "api" ]]; then
+  endpoint="${@: -1}"
+  if [[ "$endpoint" == "repos/acme/api/pulls/comments"* ]]; then
+    echo '[[]]'
+    exit 0
+  fi
+  if [[ "$endpoint" == "repos/acme/api/pulls"* ]]; then
+    cat <<JSON
+[{"id":101,"number":1,"title":"Add API","html_url":"https://example.com/pr/1","created_at":"2025-01-02T00:00:00Z","updated_at":"2025-01-02T00:00:00Z","user":{"login":"alice"},"requested_reviewers":[]}]
+JSON
+    exit 0
+  fi
+  if [[ "$endpoint" == "repos/acme/api/issues/comments"* ]]; then
+    echo '[[]]'
+    exit 0
+  fi
+  if [[ "$endpoint" == "repos/acme/api/issues"* ]]; then
+    echo '[]'
+    exit 0
+  fi
+fi
+echo "unexpected args: $@" >&2
+exit 1
+"#,
+    );
+
+    let mut cmd = cargo_bin_cmd!("gh-watch");
+    cmd.arg("once")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--dry-run")
+        .env("GH_WATCH_GH_BIN", gh_path)
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&state_db_path).unwrap();
+    let notified_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM notified_events", [], |row| row.get(0))
+        .unwrap();
+    let timeline_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM timeline_events", [], |row| row.get(0))
+        .unwrap();
+    let cursor_after: String = conn
+        .query_row(
+            "SELECT last_polled_at FROM polling_cursors WHERE repo = ?1",
+            rusqlite::params!["acme/api"],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    assert_eq!(notified_count, 0);
+    assert_eq!(timeline_count, 0);
+    assert_eq!(cursor_after, cursor.to_rfc3339());
+}
+
+#[test]
+fn report_markdown_default_includes_counts() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let state_db_path = dir.path().join("state.db");
+    write_config(&config_path, &state_db_path, &["acme/api"]);
+    seed_report_data(&state_db_path);
+
+    let mut cmd = cargo_bin_cmd!("gh-watch");
+    cmd.arg("report")
+        .arg("--config")
+        .arg(&config_path)
+        .assert()
+        .success()
+        .stdout(contains("# gh-watch report"))
+        .stdout(contains("events_total: 1"))
+        .stdout(contains("failures_total: 1"));
+}
+
+#[test]
+fn report_json_is_machine_readable() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let state_db_path = dir.path().join("state.db");
+    write_config(&config_path, &state_db_path, &["acme/api"]);
+    seed_report_data(&state_db_path);
+
+    let output = cargo_bin_cmd!("gh-watch")
+        .arg("report")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--since")
+        .arg("72h")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let raw = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(raw.trim()).unwrap();
+    assert_eq!(parsed["events_total"].as_u64().unwrap(), 1);
+    assert_eq!(parsed["failures_total"].as_u64().unwrap(), 1);
+}
+
+#[test]
+fn doctor_fails_when_gh_auth_is_invalid() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let state_db_path = dir.path().join("state.db");
+    write_config(&config_path, &state_db_path, &["acme/api"]);
+
+    let gh_path = write_stub_gh(
+        dir.path(),
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "auth" && "$2" == "status" ]]; then
+  echo "auth required" >&2
+  exit 1
+fi
+echo "unexpected args: $@" >&2
+exit 1
+"#,
+    );
+
+    let mut cmd = cargo_bin_cmd!("gh-watch");
+    cmd.arg("doctor")
+        .arg("--config")
+        .arg(&config_path)
+        .env("GH_WATCH_GH_BIN", gh_path)
+        .assert()
+        .failure()
+        .stderr(contains("GitHub authentication is invalid"));
+}
+
+#[test]
+fn doctor_succeeds_and_reports_checks() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let state_db_path = dir.path().join("state.db");
+    write_config(&config_path, &state_db_path, &["acme/api"]);
+
+    let gh_path = write_stub_gh(
+        dir.path(),
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "auth" && "$2" == "status" ]]; then
+  exit 0
+fi
+if [[ "$1" == "api" && "$2" == "user" ]]; then
+  echo "alice"
+  exit 0
+fi
+echo "unexpected args: $@" >&2
+exit 1
+"#,
+    );
+
+    let mut cmd = cargo_bin_cmd!("gh-watch");
+    cmd.arg("doctor")
+        .arg("--config")
+        .arg(&config_path)
+        .env("GH_WATCH_GH_BIN", gh_path)
+        .assert()
+        .success()
+        .stdout(contains("config doctor: ok"))
+        .stdout(contains("gh auth: ok"))
+        .stdout(contains("state db:"));
+}
+
+fn write_stub_gh(dir: &Path, script: &str) -> PathBuf {
+    let path = dir.join("gh");
+    fs::write(&path, script).unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = fs::metadata(&path).unwrap().permissions();
+        perm.set_mode(0o755);
+        fs::set_permissions(&path, perm).unwrap();
+    }
+
+    path
+}
+
+fn write_config(config_path: &Path, state_db_path: &Path, repositories: &[&str]) {
+    let escaped = state_db_path.display().to_string().replace('\\', "\\\\");
+    let mut src = format!(
+        r#"
+interval_seconds = 300
+bootstrap_lookback_hours = 24
+timeline_limit = 500
+retention_days = 90
+failure_history_limit = 200
+state_db_path = "{escaped}"
+
+[notifications]
+enabled = true
+include_url = true
+
+[poll]
+max_concurrency = 4
+timeout_seconds = 30
+"#
+    );
+
+    for repo in repositories {
+        src.push_str("\n[[repositories]]\n");
+        src.push_str(&format!("name = \"{repo}\"\n"));
+        src.push_str("enabled = true\n");
+    }
+
+    fs::write(config_path, src).unwrap();
+}
+
+fn seed_report_data(state_db_path: &Path) {
+    let store = SqliteStateStore::new(state_db_path).unwrap();
+    let now = Utc::now();
+    store
+        .append_timeline_event(&WatchEvent {
+            event_id: "ev-1".to_string(),
+            repo: "acme/api".to_string(),
+            kind: EventKind::IssueCommentCreated,
+            actor: "alice".to_string(),
+            title: "Report event".to_string(),
+            url: "https://example.com/ev-1".to_string(),
+            created_at: now - Duration::minutes(30),
+            source_item_id: "ev-1".to_string(),
+            subject_author: Some("bob".to_string()),
+            requested_reviewer: None,
+            mentions: vec!["alice".to_string()],
+        })
+        .unwrap();
+    store
+        .record_failure(&FailureRecord::new(
+            "repo_poll",
+            "acme/api",
+            now - Duration::minutes(10),
+            "temporary failure",
+        ))
+        .unwrap();
+}

--- a/tests/state_sqlite_test.rs
+++ b/tests/state_sqlite_test.rs
@@ -15,6 +15,9 @@ fn sample_event(id: &str, created_at: chrono::DateTime<Utc>) -> WatchEvent {
         url: "https://example.com/issues/1".to_string(),
         created_at,
         source_item_id: id.to_string(),
+        subject_author: Some("bob".to_string()),
+        requested_reviewer: None,
+        mentions: Vec::new(),
     }
 }
 

--- a/tests/tui_state_test.rs
+++ b/tests/tui_state_test.rs
@@ -32,6 +32,9 @@ fn ev_with(
         url: format!("https://example.com/{}", id),
         created_at: ts,
         source_item_id: id.to_string(),
+        subject_author: Some(actor.to_string()),
+        requested_reviewer: None,
+        mentions: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## 概要
監視運用をしやすくするCLI機能追加と、ドキュメント/配布まわりの整備をまとめて行いました。

## 変更内容
- CLIに `once` / `report` / `doctor` を追加
- `once` の終了コードを整理
  - `0`: 成功
  - `2`: repo単位の部分失敗
  - `1`: 致命エラー
- `once --dry-run` を追加（state不変で実行可能）
- `report --since --format` を追加（markdown/json出力）
- `only_involving_me` フィルタを追加（自分宛review request / メンション / 自分authorの更新）
- EventKindを追加
  - `pr_review_requested`
  - `pr_review_submitted`
  - `pr_merged`
- READMEを分割
  - 英語: `README.md`
  - 日本語: `README_ja.md`
- READMEから「OSS利用者向け」前提の表現を削除
- ライセンスを `MIT` から `UNLICENSED` に変更（`LICENSE` を削除）
- Release workflowを追加（macOS/Linux/Windows成果物 + checksum）

## テスト
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

上記すべてローカルで実行し、成功しています。
