### PR TITLE
WSL環境でWindows Toast通知を利用できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ Use `config.example.toml` as a shareable template.
   - `notifications.windows_app_id` を指定可能
   - 未指定時の既定値は PowerShell の AppUserModelID（`Toast::POWERSHELL_APP_ID`）
   - 未指定時は `check` / `watch` 起動時に警告を表示
+- WSL (Linux build running inside WSL):
+  - 通知は Linux デスクトップ通知ではなく `powershell.exe` 経由の Windows Toast を使用
+  - `notifications.wsl_windows_app_id` を指定可能（WSL時は `notifications.windows_app_id` を参照しない）
+  - 未指定時の既定値は PowerShell の AppUserModelID
+  - `powershell.exe` が利用できない場合:
+    - `gh-watch check` は失敗終了
+    - `gh-watch doctor` / `gh-watch watch` / `gh-watch once` は warning を表示して継続
 - いずれも、最終的なバナー表示有無は OS 側の通知設定に依存
 
 ## Developer Quality Gates

--- a/README_ja.md
+++ b/README_ja.md
@@ -150,6 +150,24 @@ gh-watch watch
 
 共有用テンプレートは `config.example.toml` を利用してください。
 
+## 通知 Sender ID
+
+- macOS:
+  - `notifications.macos_bundle_id` を指定可能（未指定時の既定値: `com.apple.Terminal`）
+  - 未指定時は `check` / `watch` 起動時に警告を表示
+- Windows:
+  - `notifications.windows_app_id` を指定可能
+  - 未指定時の既定値は PowerShell の AppUserModelID（`Toast::POWERSHELL_APP_ID`）
+  - 未指定時は `check` / `watch` 起動時に警告を表示
+- WSL（LinuxバイナリをWSL上で実行する場合）:
+  - Linuxデスクトップ通知ではなく `powershell.exe` 経由の Windows Toast を使用
+  - `notifications.wsl_windows_app_id` を指定可能（WSL時は `notifications.windows_app_id` を参照しない）
+  - 未指定時の既定値は PowerShell の AppUserModelID
+  - `powershell.exe` が利用できない場合:
+    - `gh-watch check` は失敗終了
+    - `gh-watch doctor` / `gh-watch watch` / `gh-watch once` は warning を表示して継続
+- 最終的なバナー表示有無は OS 側の通知設定に依存
+
 ## 開発時の品質ゲート
 
 - `cargo fmt --check`

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,6 +10,7 @@ enabled = true
 include_url = true
 # macos_bundle_id = "com.apple.Terminal"
 # windows_app_id = "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe"
+# wsl_windows_app_id = "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe"
 
 [filters]
 # event_kinds = ["pr_created", "issue_created", "issue_comment_created", "pr_review_comment_created", "pr_review_requested", "pr_review_submitted", "pr_merged"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -943,6 +943,7 @@ fn render_config(
     out.push_str(&format!("include_url = {include_url}\n"));
     out.push_str("# macos_bundle_id = \"com.apple.Terminal\"\n");
     out.push_str("# windows_app_id = \"{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe\"\n");
+    out.push_str("# wsl_windows_app_id = \"{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe\"\n");
     out.push('\n');
     out.push_str("[poll]\n");
     out.push_str("max_concurrency = 4\n");

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,6 +89,8 @@ pub struct NotificationConfig {
     pub macos_bundle_id: Option<String>,
     #[serde(default)]
     pub windows_app_id: Option<String>,
+    #[serde(default)]
+    pub wsl_windows_app_id: Option<String>,
 }
 
 impl Default for NotificationConfig {
@@ -98,6 +100,7 @@ impl Default for NotificationConfig {
             include_url: true,
             macos_bundle_id: None,
             windows_app_id: None,
+            wsl_windows_app_id: None,
         }
     }
 }

--- a/src/infra/notifier/linux.rs
+++ b/src/infra/notifier/linux.rs
@@ -1,10 +1,78 @@
-use anyhow::Result;
+use std::{env, fs, process::Command};
+
+use anyhow::{anyhow, Context, Result};
 
 use super::PlatformNotificationOptions;
 use crate::ports::NotificationClickSupport;
 
-pub fn check_health(_options: &PlatformNotificationOptions) -> Result<()> {
-    Ok(())
+pub const DEFAULT_WINDOWS_APP_ID: &str =
+    "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe";
+
+const POWERSHELL_BIN: &str = "powershell.exe";
+const POWERSHELL_HEALTHCHECK_SCRIPT: &str = "$null = $PSVersionTable.PSVersion";
+const POWERSHELL_TOAST_SCRIPT: &str = r#"
+[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null;
+[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] > $null;
+$appId = $env:GH_WATCH_TOAST_APP_ID;
+$title = [System.Security.SecurityElement]::Escape($env:GH_WATCH_TOAST_TITLE);
+$body = [System.Security.SecurityElement]::Escape($env:GH_WATCH_TOAST_BODY);
+$xml = New-Object Windows.Data.Xml.Dom.XmlDocument;
+$xml.LoadXml("<toast><visual><binding template='ToastGeneric'><text>$title</text><text>$body</text></binding></visual></toast>");
+$toast = [Windows.UI.Notifications.ToastNotification]::new($xml);
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($appId).Show($toast);
+"#;
+
+pub fn effective_wsl_app_id(configured: Option<&str>) -> String {
+    configured
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_WINDOWS_APP_ID)
+        .to_string()
+}
+
+fn is_wsl() -> bool {
+    let wsl_distro_name = env::var("WSL_DISTRO_NAME").ok();
+    let wsl_interop = env::var("WSL_INTEROP").ok();
+    let proc_version = fs::read_to_string("/proc/version").ok();
+
+    is_wsl_from_signals(
+        wsl_distro_name.as_deref(),
+        wsl_interop.as_deref(),
+        proc_version.as_deref(),
+    )
+}
+
+fn is_wsl_from_signals(
+    wsl_distro_name: Option<&str>,
+    wsl_interop: Option<&str>,
+    proc_version: Option<&str>,
+) -> bool {
+    if has_signal(wsl_distro_name) || has_signal(wsl_interop) {
+        return true;
+    }
+
+    proc_version
+        .map(|value| value.to_ascii_lowercase().contains("microsoft"))
+        .unwrap_or(false)
+}
+
+fn has_signal(value: Option<&str>) -> bool {
+    value
+        .map(str::trim)
+        .map(|trimmed| !trimmed.is_empty())
+        .unwrap_or(false)
+}
+
+fn check_health_with_wsl_override(_options: &PlatformNotificationOptions, wsl: bool) -> Result<()> {
+    if !wsl {
+        return Ok(());
+    }
+
+    ensure_powershell_available()
+}
+
+pub fn check_health(options: &PlatformNotificationOptions) -> Result<()> {
+    check_health_with_wsl_override(options, is_wsl())
 }
 
 pub fn click_action_support() -> NotificationClickSupport {
@@ -15,11 +83,320 @@ pub fn notify(
     title: &str,
     body: &str,
     _click_url: Option<&str>,
-    _options: &PlatformNotificationOptions,
+    options: &PlatformNotificationOptions,
 ) -> Result<()> {
+    notify_with_wsl_override(title, body, options, is_wsl())
+}
+
+fn notify_with_wsl_override(
+    title: &str,
+    body: &str,
+    options: &PlatformNotificationOptions,
+    wsl: bool,
+) -> Result<()> {
+    if wsl {
+        return notify_via_windows_toast(title, body, options);
+    }
+
     notify_rust::Notification::new()
         .summary(title)
         .body(body)
         .show()?;
     Ok(())
+}
+
+fn ensure_powershell_available() -> Result<()> {
+    let output = Command::new(POWERSHELL_BIN)
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            POWERSHELL_HEALTHCHECK_SCRIPT,
+        ])
+        .output()
+        .with_context(|| format!("failed to execute {POWERSHELL_BIN} for WSL notifications"))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        Err(anyhow!(
+            "{POWERSHELL_BIN} health check failed with status {}",
+            output.status
+        ))
+    } else {
+        Err(anyhow!(
+            "{POWERSHELL_BIN} health check failed with status {}: {}",
+            output.status,
+            stderr
+        ))
+    }
+}
+
+fn notify_via_windows_toast(
+    title: &str,
+    body: &str,
+    options: &PlatformNotificationOptions,
+) -> Result<()> {
+    let app_id = effective_wsl_app_id(options.wsl_windows_app_id.as_deref());
+    let output = Command::new(POWERSHELL_BIN)
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            POWERSHELL_TOAST_SCRIPT,
+        ])
+        .env("GH_WATCH_TOAST_APP_ID", &app_id)
+        .env("GH_WATCH_TOAST_TITLE", title)
+        .env("GH_WATCH_TOAST_BODY", body)
+        .output()
+        .with_context(|| format!("failed to execute {POWERSHELL_BIN} for WSL notifications"))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        Err(anyhow!(
+            "{POWERSHELL_BIN} toast command failed with status {}",
+            output.status
+        ))
+    } else {
+        Err(anyhow!(
+            "{POWERSHELL_BIN} toast command failed with status {}: {}",
+            output.status,
+            stderr
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        env, fs,
+        io::Write,
+        path::{Path, PathBuf},
+        sync::{Mutex, OnceLock},
+    };
+
+    use tempfile::tempdir;
+
+    use super::{
+        check_health_with_wsl_override, effective_wsl_app_id, is_wsl_from_signals,
+        notify_with_wsl_override, DEFAULT_WINDOWS_APP_ID,
+    };
+    use crate::infra::notifier::PlatformNotificationOptions;
+
+    #[test]
+    fn wsl_detection_is_true_when_distro_env_is_set() {
+        assert!(is_wsl_from_signals(Some("Ubuntu"), None, None));
+    }
+
+    #[test]
+    fn wsl_detection_is_true_when_interop_env_is_set() {
+        assert!(is_wsl_from_signals(
+            None,
+            Some("/run/WSL/123_interop"),
+            None
+        ));
+    }
+
+    #[test]
+    fn wsl_detection_is_true_when_proc_version_mentions_microsoft() {
+        assert!(is_wsl_from_signals(
+            None,
+            None,
+            Some("Linux version 5.15.167.4-microsoft-standard-WSL2")
+        ));
+    }
+
+    #[test]
+    fn wsl_detection_is_false_without_any_signals() {
+        assert!(!is_wsl_from_signals(
+            None,
+            None,
+            Some("Linux version 6.8.0-generic")
+        ));
+    }
+
+    #[test]
+    fn effective_wsl_app_id_uses_default_when_missing() {
+        assert_eq!(effective_wsl_app_id(None), DEFAULT_WINDOWS_APP_ID);
+    }
+
+    #[test]
+    fn check_health_in_wsl_requires_powershell() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let path_guard = EnvVarGuard::set("PATH", "");
+
+        let options = PlatformNotificationOptions::default();
+        let result = check_health_with_wsl_override(&options, true);
+
+        drop(path_guard);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn check_health_in_wsl_succeeds_when_powershell_exists() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = tempdir().unwrap();
+        let script_path = write_stub_powershell(
+            dir.path(),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+"#,
+        );
+        assert!(script_path.exists());
+
+        let original_path = env::var("PATH").unwrap_or_default();
+        let joined_path = join_path_front(dir.path(), &original_path);
+        let path_guard = EnvVarGuard::set("PATH", &joined_path);
+
+        let options = PlatformNotificationOptions::default();
+        let result = check_health_with_wsl_override(&options, true);
+
+        drop(path_guard);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn wsl_notify_uses_powershell_and_prefers_wsl_app_id() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = tempdir().unwrap();
+        let output_path = dir.path().join("toast_env.txt");
+        let script_path = write_stub_powershell(
+            dir.path(),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf '%s\n' "${GH_WATCH_TOAST_APP_ID}"
+  printf '%s\n' "${GH_WATCH_TOAST_TITLE}"
+  printf '%s\n' "${GH_WATCH_TOAST_BODY}"
+} > "${GH_WATCH_TEST_OUTPUT}"
+"#,
+        );
+        assert!(script_path.exists());
+
+        let original_path = env::var("PATH").unwrap_or_default();
+        let joined_path = join_path_front(dir.path(), &original_path);
+        let path_guard = EnvVarGuard::set("PATH", &joined_path);
+        let output_guard =
+            EnvVarGuard::set("GH_WATCH_TEST_OUTPUT", &output_path.display().to_string());
+
+        let options = PlatformNotificationOptions {
+            macos_bundle_id: None,
+            windows_app_id: Some("com.example.ShouldBeIgnored".to_string()),
+            wsl_windows_app_id: Some("com.example.WslPreferred".to_string()),
+        };
+
+        let result = notify_with_wsl_override("T", "B", &options, true);
+
+        drop(output_guard);
+        drop(path_guard);
+        assert!(result.is_ok());
+
+        let output = fs::read_to_string(output_path).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines, vec!["com.example.WslPreferred", "T", "B"]);
+    }
+
+    #[test]
+    fn wsl_notify_returns_error_when_powershell_fails() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = tempdir().unwrap();
+        let script_path = write_stub_powershell(
+            dir.path(),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+echo "toast failed" >&2
+exit 23
+"#,
+        );
+        assert!(script_path.exists());
+
+        let original_path = env::var("PATH").unwrap_or_default();
+        let joined_path = join_path_front(dir.path(), &original_path);
+        let path_guard = EnvVarGuard::set("PATH", &joined_path);
+
+        let options = PlatformNotificationOptions {
+            macos_bundle_id: None,
+            windows_app_id: None,
+            wsl_windows_app_id: None,
+        };
+        let result = notify_with_wsl_override("T", "B", &options, true);
+
+        drop(path_guard);
+        assert!(result.is_err());
+    }
+
+    fn write_stub_powershell(dir: &Path, script: &str) -> PathBuf {
+        let path = dir.join("powershell.exe");
+        let mut file = fs::File::create(&path).unwrap();
+        file.write_all(script.as_bytes()).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(&path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&path, permissions).unwrap();
+        }
+
+        path
+    }
+
+    fn join_path_front(path: &Path, existing: &str) -> String {
+        if existing.is_empty() {
+            path.display().to_string()
+        } else {
+            format!("{}:{existing}", path.display())
+        }
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvVarGuard {
+        key: String,
+        old: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &str, value: &str) -> Self {
+            let old = env::var(key).ok();
+            env::set_var(key, value);
+            Self {
+                key: key.to_string(),
+                old,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(old) = &self.old {
+                env::set_var(&self.key, old);
+            } else {
+                env::remove_var(&self.key);
+            }
+        }
+    }
 }

--- a/src/infra/notifier/mod.rs
+++ b/src/infra/notifier/mod.rs
@@ -31,6 +31,8 @@ pub(super) struct PlatformNotificationOptions {
     pub(super) macos_bundle_id: Option<String>,
     #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     pub(super) windows_app_id: Option<String>,
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub(super) wsl_windows_app_id: Option<String>,
 }
 
 impl PlatformNotificationOptions {
@@ -38,6 +40,7 @@ impl PlatformNotificationOptions {
         Self {
             macos_bundle_id: config.macos_bundle_id.clone(),
             windows_app_id: config.windows_app_id.clone(),
+            wsl_windows_app_id: config.wsl_windows_app_id.clone(),
         }
     }
 

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -41,6 +41,7 @@ name = "octocat/hello-world"
     assert!(cfg.notifications.include_url);
     assert!(cfg.notifications.macos_bundle_id.is_none());
     assert!(cfg.notifications.windows_app_id.is_none());
+    assert!(cfg.notifications.wsl_windows_app_id.is_none());
     assert!(cfg.filters.event_kinds.is_empty());
     assert!(cfg.filters.ignore_actors.is_empty());
     assert!(!cfg.filters.only_involving_me);
@@ -56,6 +57,7 @@ enabled = true
 include_url = true
 macos_bundle_id = "com.example.CustomMacApp"
 windows_app_id = "com.example.CustomWinApp"
+wsl_windows_app_id = "com.example.CustomWslApp"
 
 [[repositories]]
 name = "octocat/hello-world"
@@ -69,6 +71,10 @@ name = "octocat/hello-world"
     assert_eq!(
         cfg.notifications.windows_app_id.as_deref(),
         Some("com.example.CustomWinApp")
+    );
+    assert_eq!(
+        cfg.notifications.wsl_windows_app_id.as_deref(),
+        Some("com.example.CustomWslApp")
     );
 }
 

--- a/tests/poll_once_test.rs
+++ b/tests/poll_once_test.rs
@@ -269,6 +269,7 @@ fn cfg() -> Config {
             include_url: true,
             macos_bundle_id: None,
             windows_app_id: None,
+            wsl_windows_app_id: None,
         },
         filters: FiltersConfig::default(),
         poll: PollConfig {

--- a/tests/watch_e2e_test.rs
+++ b/tests/watch_e2e_test.rs
@@ -87,6 +87,7 @@ exit 1
             include_url: true,
             macos_bundle_id: None,
             windows_app_id: None,
+            wsl_windows_app_id: None,
         },
         filters: FiltersConfig::default(),
         poll: PollConfig {


### PR DESCRIPTION
## 概要
WSL上で `gh-watch` を実行したとき、Linux通知ではなく `powershell.exe` 経由で Windows Toast 通知を送るようにしました。

## 背景
WSL環境では Linux 側の通知基盤が使えない/見えないことがあり、通知が届かないケースがあるためです。

## 変更内容
- `notifications.wsl_windows_app_id` を設定キーとして追加
- Linux notifier に WSL判定を追加（`WSL_DISTRO_NAME` / `WSL_INTEROP` / `/proc/version`）
- WSL時は `powershell.exe` で Windows Toast を送信
- WSL時は `notifications.windows_app_id` を参照せず、`wsl_windows_app_id` のみ使用
- WSL時の `check_health` で `powershell.exe` 実行可否を検証
  - `gh-watch check` は失敗終了
  - `gh-watch doctor` / `gh-watch watch` / `gh-watch once` は warning を表示して継続
- `config.example.toml` / `init` 生成テンプレート / README(日英) を更新

## 影響範囲
- Linux通常環境（WSL以外）は従来どおり `notify-rust` を使用
- macOS/Windows の通知実装には変更なし

## テスト
- 追加: configパースの `wsl_windows_app_id` テスト
- 追加: Linux notifier の WSL検知 / health check / powershell送信 / 失敗時エラーのユニットテスト
- 実行:
  - `cargo fmt --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test --quiet`

## 補足
`cargo check --target x86_64-unknown-linux-gnu --tests` は、この実行環境で Rust target が未導入のため確認できていません。
