### PR TITLE
通知デバッグ用コマンド notification-test を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,13 @@ gh-watch watch
 - `gh-watch report [--config <path>] [--since <duration>] [--format markdown|json]`
 - `gh-watch doctor [--config <path>]`
 - `gh-watch check [--config <path>]`
+- `gh-watch notification-test`
 - `gh-watch init [--path <path>] [--force] [--interactive] [--reset-state]`
 - `gh-watch config open|edit`
 - `gh-watch config path`
 - `gh-watch config doctor`
+
+`notification-test` sends one debug notification by directly calling the notifier dispatch function.
 
 ### `once` Exit Codes
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -77,10 +77,13 @@ gh-watch watch
 - `gh-watch report [--config <path>] [--since <duration>] [--format markdown|json]`
 - `gh-watch doctor [--config <path>]`
 - `gh-watch check [--config <path>]`
+- `gh-watch notification-test`
 - `gh-watch init [--path <path>] [--force] [--interactive] [--reset-state]`
 - `gh-watch config open|edit`
 - `gh-watch config path`
 - `gh-watch config doctor`
+
+`notification-test` は notifier の送信関数を直接呼び出して、デバッグ用に通知を1回送信します。
 
 ### `once` の終了コード
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,2 +1,3 @@
+pub mod notification_test;
 pub mod poll_once;
 pub mod watch_loop;

--- a/src/app/notification_test.rs
+++ b/src/app/notification_test.rs
@@ -1,0 +1,45 @@
+use anyhow::{Context, Result};
+use chrono::Utc;
+
+use crate::{
+    domain::events::{EventKind, WatchEvent},
+    ports::{NotificationDispatchResult, NotifierPort},
+};
+
+#[derive(Debug, Clone)]
+pub struct NotificationTestOutcome {
+    pub event_key: String,
+    pub dispatch_result: NotificationDispatchResult,
+}
+
+pub fn run_notification_test<N>(notifier: &N) -> Result<NotificationTestOutcome>
+where
+    N: NotifierPort,
+{
+    let event = build_test_event();
+    let dispatch_result = notifier
+        .notify(&event, true)
+        .context("failed to send test notification")?;
+
+    Ok(NotificationTestOutcome {
+        event_key: event.event_key(),
+        dispatch_result,
+    })
+}
+
+fn build_test_event() -> WatchEvent {
+    let now = Utc::now();
+    WatchEvent {
+        event_id: "notification-test".to_string(),
+        repo: "gh-watch".to_string(),
+        kind: EventKind::IssueCommentCreated,
+        actor: "gh-watch".to_string(),
+        title: "gh-watch notification test".to_string(),
+        url: "https://github.com/6uclz1/gh-watch".to_string(),
+        created_at: now,
+        source_item_id: now.timestamp_millis().to_string(),
+        subject_author: Some("gh-watch".to_string()),
+        requested_reviewer: None,
+        mentions: Vec::new(),
+    }
+}

--- a/tests/notification_test_usecase_test.rs
+++ b/tests/notification_test_usecase_test.rs
@@ -1,0 +1,82 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::{anyhow, Result};
+use gh_watch::app::notification_test::run_notification_test;
+use gh_watch::domain::events::WatchEvent;
+use gh_watch::ports::{NotificationClickSupport, NotificationDispatchResult, NotifierPort};
+
+#[derive(Clone)]
+enum NotifyOutcome {
+    Success(NotificationDispatchResult),
+    Failure(String),
+}
+
+#[derive(Clone)]
+struct FakeNotifier {
+    calls: Arc<Mutex<Vec<(WatchEvent, bool)>>>,
+    outcome: NotifyOutcome,
+}
+
+impl FakeNotifier {
+    fn success(result: NotificationDispatchResult) -> Self {
+        Self {
+            calls: Arc::new(Mutex::new(Vec::new())),
+            outcome: NotifyOutcome::Success(result),
+        }
+    }
+
+    fn failure(message: &str) -> Self {
+        Self {
+            calls: Arc::new(Mutex::new(Vec::new())),
+            outcome: NotifyOutcome::Failure(message.to_string()),
+        }
+    }
+}
+
+impl NotifierPort for FakeNotifier {
+    fn check_health(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn click_action_support(&self) -> NotificationClickSupport {
+        NotificationClickSupport::Unsupported
+    }
+
+    fn notify(&self, event: &WatchEvent, include_url: bool) -> Result<NotificationDispatchResult> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((event.clone(), include_url));
+        match &self.outcome {
+            NotifyOutcome::Success(result) => Ok(*result),
+            NotifyOutcome::Failure(message) => Err(anyhow!("{message}")),
+        }
+    }
+}
+
+#[test]
+fn notification_test_runs_notify_once_with_include_url_enabled() {
+    let notifier = FakeNotifier::success(NotificationDispatchResult::Delivered);
+
+    let outcome = run_notification_test(&notifier).unwrap();
+
+    let calls = notifier.calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert!(calls[0].1);
+    assert_eq!(
+        outcome.dispatch_result,
+        NotificationDispatchResult::Delivered
+    );
+    assert_eq!(outcome.event_key, calls[0].0.event_key());
+}
+
+#[test]
+fn notification_test_returns_error_when_notify_fails() {
+    let notifier = FakeNotifier::failure("notification boom");
+
+    let err = run_notification_test(&notifier).unwrap_err();
+
+    assert!(format!("{err:#}").contains("failed to send test notification"));
+    let calls = notifier.calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+}

--- a/tests/once_report_doctor_cmd_test.rs
+++ b/tests/once_report_doctor_cmd_test.rs
@@ -85,7 +85,8 @@ fn help_lists_once_report_and_doctor_commands() {
         .success()
         .stdout(contains("once"))
         .stdout(contains("report"))
-        .stdout(contains("doctor"));
+        .stdout(contains("doctor"))
+        .stdout(contains("notification-test"));
 }
 
 #[test]


### PR DESCRIPTION
## 概要
通知が届かない現象の切り分けをしやすくするため、`gh-watch notification-test` を追加しました。

このコマンドは **通知送信関数の疎通確認に特化** しており、config 読み込み・GitHub API 認証・state DB 確認は行いません。

## 変更内容
- CLI サブコマンド `notification-test` を追加
- 通知テスト用ユースケース `run_notification_test` を追加
  - テストイベントを1件作成
  - `notifier.notify(..., true)` を1回実行
  - dispatch結果と event_key を返却
- 実行ログを追加
  - `start` / `warning` / `sending test notification` / `delivered` / `event_key`
- テスト追加
  - `notification_test_usecase_test`（成功系・失敗系）
  - `--help` に `notification-test` が表示されることを検証
- README / README_ja のコマンド一覧を更新

## 使い方
```bash
gh-watch notification-test
```

## 確認手順
- `cargo fmt --check`
- `cargo test`
- `cargo run -- notification-test`

## 補足
`notification-test` は通知基盤の疎通確認専用です。
`gh auth` や state DB を含む総合診断は既存の `check` / `doctor` を利用してください。
